### PR TITLE
Specify to install clippy & rustfmt

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,8 @@ jobs:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
       - run: cargo check
       - run: cargo fmt --all -- --check
       - run: cargo clippy -- -D warnings


### PR DESCRIPTION
These used to be installed by default, but for some reason that has stopped, and I guess I need to specify them now.